### PR TITLE
Pass SkipClaimsValidation to jwt lib.

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -69,8 +69,12 @@ func NewParserWithOpts(keysProvider KeysProvider, logger log.FieldLogger, opts P
 	for _, audPattern := range opts.ExpectedAudience {
 		audienceMatchers = append(audienceMatchers, glob.Compile(audPattern))
 	}
+	parserOpts := []jwtgo.ParserOption{jwtgo.WithExpirationRequired()}
+	if opts.SkipClaimsValidation {
+		parserOpts = append(parserOpts, jwtgo.WithoutClaimsValidation())
+	}
 	return &Parser{
-		parser:                        jwtgo.NewParser(jwtgo.WithExpirationRequired()),
+		parser:                        jwtgo.NewParser(parserOpts...),
 		claimsValidator:               jwtgo.NewValidator(jwtgo.WithExpirationRequired()),
 		customValidator:               makeCustomAudienceValidator(opts.RequireAudience, audienceMatchers),
 		skipClaimsValidation:          opts.SkipClaimsValidation,


### PR DESCRIPTION
This PR passes the SkipClaimsValidation to the underlying parser, otherwise, it does not skip certain checks. If the caller explicitly sets it in the opts, it also wants it applied to the underlying lib.