### PR TITLE
Use term "endpoint" instead of "target" for gRPC server address

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -134,12 +134,12 @@ func NewTokenIntrospector(
 	}
 
 	var grpcClient *idptoken.GRPCClient
-	if cfg.Introspection.GRPC.Target != "" {
+	if cfg.Introspection.GRPC.Endpoint != "" {
 		transportCreds, err := makeGRPCTransportCredentials(cfg.Introspection.GRPC.TLS)
 		if err != nil {
 			return nil, fmt.Errorf("make grpc transport credentials: %w", err)
 		}
-		grpcClient, err = idptoken.NewGRPCClientWithOpts(cfg.Introspection.GRPC.Target, transportCreds,
+		grpcClient, err = idptoken.NewGRPCClientWithOpts(cfg.Introspection.GRPC.Endpoint, transportCreds,
 			idptoken.GRPCClientOpts{RequestTimeout: cfg.GRPCClient.RequestTimeout, Logger: logger})
 		if err != nil {
 			return nil, fmt.Errorf("new grpc client: %w", err)

--- a/auth_test.go
+++ b/auth_test.go
@@ -279,7 +279,7 @@ func TestNewTokenIntrospector(t *gotesting.T) {
 				Introspection: IntrospectionConfig{
 					Enabled: true,
 					GRPC: IntrospectionGRPCConfig{
-						Target: grpcIDPSrv.Addr(),
+						Endpoint: grpcIDPSrv.Addr(),
 						TLS: GRPCTLSConfig{
 							Enabled: true,
 							CACert:  certFile,

--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ const (
 	cfgKeyJWKSCacheUpdateMinInterval           = "auth.jwks.cache.updateMinInterval"
 	cfgKeyIntrospectionEnabled                 = "auth.introspection.enabled"
 	cfgKeyIntrospectionEndpoint                = "auth.introspection.endpoint"
-	cfgKeyIntrospectionGRPCTarget              = "auth.introspection.grpc.target"
+	cfgKeyIntrospectionGRPCEndpoint            = "auth.introspection.grpc.endpoint"
 	cfgKeyIntrospectionGRPCTLSEnabled          = "auth.introspection.grpc.tls.enabled"
 	cfgKeyIntrospectionGRPCTLSCACert           = "auth.introspection.grpc.tls.caCert"
 	cfgKeyIntrospectionGRPCTLSClientCert       = "auth.introspection.grpc.tls.clientCert"
@@ -89,7 +89,7 @@ type IntrospectionCacheConfig struct {
 
 // IntrospectionGRPCConfig is a configuration of how token will be introspected via gRPC.
 type IntrospectionGRPCConfig struct {
-	Target         string
+	Endpoint       string
 	RequestTimeout time.Duration
 	TLS            GRPCTLSConfig
 }
@@ -231,7 +231,7 @@ func (c *Config) setIntrospectionConfig(dp config.DataProvider) error {
 	}
 
 	// GRPC
-	if c.Introspection.GRPC.Target, err = dp.GetString(cfgKeyIntrospectionGRPCTarget); err != nil {
+	if c.Introspection.GRPC.Endpoint, err = dp.GetString(cfgKeyIntrospectionGRPCEndpoint); err != nil {
 		return err
 	}
 	if c.Introspection.GRPC.TLS.Enabled, err = dp.GetBool(cfgKeyIntrospectionGRPCTLSEnabled); err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -56,7 +56,7 @@ auth:
     accessTokenScope:
       - token_introspector
     grpc:
-      target: "127.0.0.1:1234"
+      endpoint: "127.0.0.1:1234"
       tls:
         enabled: true
         caCert: ca-cert.pem
@@ -102,7 +102,7 @@ auth:
 			},
 			AccessTokenScope: []string{"token_introspector"},
 			GRPC: IntrospectionGRPCConfig{
-				Target: "127.0.0.1:1234",
+				Endpoint: "127.0.0.1:1234",
 				TLS: GRPCTLSConfig{
 					Enabled:    true,
 					CACert:     "ca-cert.pem",


### PR DESCRIPTION
The main goal of this change is to be consistent with HTTP configuration.