### PR TITLE
Implement introspection endpoint discovery cache

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,29 +20,32 @@ import (
 )
 
 const (
-	cfgKeyHTTPClientRequestTimeout             = "auth.httpClient.requestTimeout"
-	cfgKeyGRPCClientRequestTimeout             = "auth.grpcClient.requestTimeout"
-	cfgKeyJWTTrustedIssuers                    = "auth.jwt.trustedIssuers"
-	cfgKeyJWTTrustedIssuerURLs                 = "auth.jwt.trustedIssuerUrls"
-	cfgKeyJWTRequireAudience                   = "auth.jwt.requireAudience"
-	cfgKeyJWTExceptedAudience                  = "auth.jwt.expectedAudience"
-	cfgKeyJWTClaimsCacheEnabled                = "auth.jwt.claimsCache.enabled"
-	cfgKeyJWTClaimsCacheMaxEntries             = "auth.jwt.claimsCache.maxEntries"
-	cfgKeyJWKSCacheUpdateMinInterval           = "auth.jwks.cache.updateMinInterval"
-	cfgKeyIntrospectionEnabled                 = "auth.introspection.enabled"
-	cfgKeyIntrospectionEndpoint                = "auth.introspection.endpoint"
-	cfgKeyIntrospectionGRPCEndpoint            = "auth.introspection.grpc.endpoint"
-	cfgKeyIntrospectionGRPCTLSEnabled          = "auth.introspection.grpc.tls.enabled"
-	cfgKeyIntrospectionGRPCTLSCACert           = "auth.introspection.grpc.tls.caCert"
-	cfgKeyIntrospectionGRPCTLSClientCert       = "auth.introspection.grpc.tls.clientCert"
-	cfgKeyIntrospectionGRPCTLSClientKey        = "auth.introspection.grpc.tls.clientKey"
-	cfgKeyIntrospectionAccessTokenScope        = "auth.introspection.accessTokenScope" // nolint:gosec // false positive
-	cfgKeyIntrospectionClaimsCacheEnabled      = "auth.introspection.claimsCache.enabled"
-	cfgKeyIntrospectionClaimsCacheMaxEntries   = "auth.introspection.claimsCache.maxEntries"
-	cfgKeyIntrospectionClaimsCacheTTL          = "auth.introspection.claimsCache.ttl"
-	cfgKeyIntrospectionNegativeCacheEnabled    = "auth.introspection.negativeCache.enabled"
-	cfgKeyIntrospectionNegativeCacheMaxEntries = "auth.introspection.negativeCache.maxEntries"
-	cfgKeyIntrospectionNegativeCacheTTL        = "auth.introspection.negativeCache.ttl"
+	cfgKeyHTTPClientRequestTimeout                      = "auth.httpClient.requestTimeout"
+	cfgKeyGRPCClientRequestTimeout                      = "auth.grpcClient.requestTimeout"
+	cfgKeyJWTTrustedIssuers                             = "auth.jwt.trustedIssuers"
+	cfgKeyJWTTrustedIssuerURLs                          = "auth.jwt.trustedIssuerUrls"
+	cfgKeyJWTRequireAudience                            = "auth.jwt.requireAudience"
+	cfgKeyJWTExceptedAudience                           = "auth.jwt.expectedAudience"
+	cfgKeyJWTClaimsCacheEnabled                         = "auth.jwt.claimsCache.enabled"
+	cfgKeyJWTClaimsCacheMaxEntries                      = "auth.jwt.claimsCache.maxEntries"
+	cfgKeyJWKSCacheUpdateMinInterval                    = "auth.jwks.cache.updateMinInterval"
+	cfgKeyIntrospectionEnabled                          = "auth.introspection.enabled"
+	cfgKeyIntrospectionEndpoint                         = "auth.introspection.endpoint"
+	cfgKeyIntrospectionGRPCEndpoint                     = "auth.introspection.grpc.endpoint"
+	cfgKeyIntrospectionGRPCTLSEnabled                   = "auth.introspection.grpc.tls.enabled"
+	cfgKeyIntrospectionGRPCTLSCACert                    = "auth.introspection.grpc.tls.caCert"
+	cfgKeyIntrospectionGRPCTLSClientCert                = "auth.introspection.grpc.tls.clientCert"
+	cfgKeyIntrospectionGRPCTLSClientKey                 = "auth.introspection.grpc.tls.clientKey"
+	cfgKeyIntrospectionAccessTokenScope                 = "auth.introspection.accessTokenScope" // nolint:gosec // false positive
+	cfgKeyIntrospectionClaimsCacheEnabled               = "auth.introspection.claimsCache.enabled"
+	cfgKeyIntrospectionClaimsCacheMaxEntries            = "auth.introspection.claimsCache.maxEntries"
+	cfgKeyIntrospectionClaimsCacheTTL                   = "auth.introspection.claimsCache.ttl"
+	cfgKeyIntrospectionNegativeCacheEnabled             = "auth.introspection.negativeCache.enabled"
+	cfgKeyIntrospectionNegativeCacheMaxEntries          = "auth.introspection.negativeCache.maxEntries"
+	cfgKeyIntrospectionNegativeCacheTTL                 = "auth.introspection.negativeCache.ttl"
+	cfgKeyIntrospectionEndpointDiscoveryCacheEnabled    = "auth.introspection.endpointDiscoveryCache.enabled"
+	cfgKeyIntrospectionEndpointDiscoveryCacheMaxEntries = "auth.introspection.endpointDiscoveryCache.maxEntries"
+	cfgKeyIntrospectionEndpointDiscoveryCacheTTL        = "auth.introspection.endpointDiscoveryCache.ttl"
 )
 
 // JWTConfig is configuration of how JWT will be verified.
@@ -68,8 +71,9 @@ type IntrospectionConfig struct {
 	Endpoint         string
 	AccessTokenScope []string
 
-	ClaimsCache   IntrospectionCacheConfig
-	NegativeCache IntrospectionCacheConfig
+	ClaimsCache            IntrospectionCacheConfig
+	NegativeCache          IntrospectionCacheConfig
+	EndpointDiscoveryCache IntrospectionCacheConfig
 
 	GRPC IntrospectionGRPCConfig
 }
@@ -145,12 +149,19 @@ func (c *Config) KeyPrefix() string {
 func (c *Config) SetProviderDefaults(dp config.DataProvider) {
 	dp.SetDefault(cfgKeyHTTPClientRequestTimeout, idputil.DefaultHTTPRequestTimeout.String())
 	dp.SetDefault(cfgKeyGRPCClientRequestTimeout, idptoken.DefaultGRPCClientRequestTimeout.String())
+
 	dp.SetDefault(cfgKeyJWTClaimsCacheMaxEntries, jwt.DefaultClaimsCacheMaxEntries)
 	dp.SetDefault(cfgKeyJWKSCacheUpdateMinInterval, jwks.DefaultCacheUpdateMinInterval.String())
+
 	dp.SetDefault(cfgKeyIntrospectionClaimsCacheMaxEntries, idptoken.DefaultIntrospectionClaimsCacheMaxEntries)
 	dp.SetDefault(cfgKeyIntrospectionClaimsCacheTTL, idptoken.DefaultIntrospectionClaimsCacheTTL.String())
+
 	dp.SetDefault(cfgKeyIntrospectionNegativeCacheMaxEntries, idptoken.DefaultIntrospectionNegativeCacheMaxEntries)
 	dp.SetDefault(cfgKeyIntrospectionNegativeCacheTTL, idptoken.DefaultIntrospectionNegativeCacheTTL.String())
+
+	dp.SetDefault(cfgKeyIntrospectionEndpointDiscoveryCacheEnabled, true)
+	dp.SetDefault(cfgKeyIntrospectionEndpointDiscoveryCacheMaxEntries, idptoken.DefaultIntrospectionEndpointDiscoveryCacheMaxEntries)
+	dp.SetDefault(cfgKeyIntrospectionEndpointDiscoveryCacheTTL, idptoken.DefaultIntrospectionEndpointDiscoveryCacheTTL.String())
 }
 
 // Set sets auth configuration values from config.DataProvider.
@@ -276,6 +287,26 @@ func (c *Config) setIntrospectionConfig(dp config.DataProvider) error {
 		return dp.WrapKeyErr(cfgKeyIntrospectionNegativeCacheMaxEntries, fmt.Errorf("max entries should be non-negative"))
 	}
 	if c.Introspection.NegativeCache.TTL, err = dp.GetDuration(cfgKeyIntrospectionNegativeCacheTTL); err != nil {
+		return err
+	}
+
+	// OpenID configuration cache
+	if c.Introspection.EndpointDiscoveryCache.Enabled, err = dp.GetBool(
+		cfgKeyIntrospectionEndpointDiscoveryCacheEnabled,
+	); err != nil {
+		return err
+	}
+	if c.Introspection.EndpointDiscoveryCache.MaxEntries, err = dp.GetInt(
+		cfgKeyIntrospectionEndpointDiscoveryCacheMaxEntries,
+	); err != nil {
+		return err
+	}
+	if c.Introspection.EndpointDiscoveryCache.MaxEntries < 0 {
+		return dp.WrapKeyErr(cfgKeyIntrospectionEndpointDiscoveryCacheMaxEntries, fmt.Errorf("max entries should be non-negative"))
+	}
+	if c.Introspection.EndpointDiscoveryCache.TTL, err = dp.GetDuration(
+		cfgKeyIntrospectionEndpointDiscoveryCacheTTL,
+	); err != nil {
 		return err
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -46,13 +46,17 @@ auth:
     enabled: true
     endpoint: https://my-idp.com/introspect
     claimsCache:
-        enabled: true
-        maxEntries: 42000
-        ttl: 42s
+      enabled: true
+      maxEntries: 42000
+      ttl: 42s
     negativeCache:
-        enabled: true
-        maxEntries: 777
-        ttl: 77s
+      enabled: true
+      maxEntries: 777
+      ttl: 77m
+    endpointDiscoveryCache:
+      enabled: true
+      maxEntries: 73
+      ttl: 7h
     accessTokenScope:
       - token_introspector
     grpc:
@@ -98,7 +102,12 @@ auth:
 			NegativeCache: IntrospectionCacheConfig{
 				Enabled:    true,
 				MaxEntries: 777,
-				TTL:        time.Second * 77,
+				TTL:        time.Minute * 77,
+			},
+			EndpointDiscoveryCache: IntrospectionCacheConfig{
+				Enabled:    true,
+				MaxEntries: 73,
+				TTL:        time.Hour * 7,
 			},
 			AccessTokenScope: []string{"token_introspector"},
 			GRPC: IntrospectionGRPCConfig{

--- a/idptest/jwks_handler.go
+++ b/idptest/jwks_handler.go
@@ -95,6 +95,11 @@ func (h *JWKSHandler) ServedCount() uint64 {
 	return h.servedCount.Load()
 }
 
+// ResetServedCount resets the number of times JWKS handler has been served.
+func (h *JWKSHandler) ResetServedCount() {
+	h.servedCount.Store(0)
+}
+
 type PublicJWKSResponse struct {
 	Keys []PublicJWK `json:"keys"`
 }

--- a/idptest/openid_configuration_handler.go
+++ b/idptest/openid_configuration_handler.go
@@ -46,6 +46,11 @@ func (h *OpenIDConfigurationHandler) ServedCount() uint64 {
 	return h.servedCount.Load()
 }
 
+// ResetServedCount resets the number of times the handler has been served.
+func (h *OpenIDConfigurationHandler) ResetServedCount() {
+	h.servedCount.Store(0)
+}
+
 // OpenIDConfigurationResponse is a response for .well-known/openid-configuration endpoint.
 type OpenIDConfigurationResponse struct {
 	TokenEndpoint         string `json:"token_endpoint"`

--- a/idptest/token_handlers.go
+++ b/idptest/token_handlers.go
@@ -87,6 +87,11 @@ func (h *TokenHandler) ServedCount() uint64 {
 	return h.servedCount.Load()
 }
 
+// ResetServedCount resets the number of times the handler has been served.
+func (h *TokenHandler) ResetServedCount() {
+	h.servedCount.Store(0)
+}
+
 // TokenResponse is a response for POST /idp/token endpoint.
 type TokenResponse struct {
 	AccessToken string `json:"access_token"`
@@ -148,4 +153,9 @@ func (h *TokenIntrospectionHandler) ServeHTTP(rw http.ResponseWriter, r *http.Re
 // ServedCount returns the number of times the handler has been served.
 func (h *TokenIntrospectionHandler) ServedCount() uint64 {
 	return h.servedCount.Load()
+}
+
+// ResetServedCount resets the number of times the handler has been served.
+func (h *TokenIntrospectionHandler) ResetServedCount() {
+	h.servedCount.Store(0)
 }

--- a/idptoken/provider.go
+++ b/idptoken/provider.go
@@ -32,7 +32,6 @@ const (
 	defaultMinRefreshPeriod = time.Second * 10
 	defaultExpirationOffset = time.Minute * 30
 	expiryDeltaMaxOffset    = 5
-	wellKnownPath           = "/.well-known/openid-configuration"
 )
 
 // ErrSourceNotRegistered is returned if GetToken is requested for the unknown Source
@@ -541,7 +540,7 @@ func (ti *oauth2Issuer) ensureTokenURL(ctx context.Context, customHeaders map[st
 		return nil
 	}
 
-	openIDCfgURL := strings.TrimSuffix(ti.baseURL, "/") + wellKnownPath
+	openIDCfgURL := strings.TrimSuffix(ti.baseURL, "/") + idputil.OpenIDConfigurationPath
 	openIDCfg, err := idputil.GetOpenIDConfiguration(
 		ctx, ti.httpClient, openIDCfgURL, customHeaders, ti.logger, ti.promMetrics)
 	if err != nil {

--- a/internal/idputil/openid_configuration.go
+++ b/internal/idputil/openid_configuration.go
@@ -18,6 +18,8 @@ import (
 	"github.com/acronis/go-authkit/internal/metrics"
 )
 
+const OpenIDConfigurationPath = "/.well-known/openid-configuration"
+
 type OpenIDConfiguration struct {
 	TokenURL              string `json:"token_endpoint"`
 	IntrospectionEndpoint string `json:"introspection_endpoint"`

--- a/jwks/client.go
+++ b/jwks/client.go
@@ -23,8 +23,6 @@ import (
 	"github.com/acronis/go-authkit/internal/metrics"
 )
 
-const OpenIDConfigurationPath = "/.well-known/openid-configuration"
-
 type jwksData struct {
 	Keys []*gojwk.Key `json:"keys"`
 }
@@ -69,7 +67,7 @@ func NewClientWithOpts(opts ClientOpts) *Client {
 func (c *Client) getRSAPubKeysForIssuer(ctx context.Context, issuerURL string) (map[string]interface{}, error) {
 	logger := idputil.GetLoggerFromProvider(ctx, c.loggerProvider)
 
-	openIDConfigURL := strings.TrimPrefix(issuerURL, "/") + OpenIDConfigurationPath
+	openIDConfigURL := strings.TrimPrefix(issuerURL, "/") + idputil.OpenIDConfigurationPath
 	openIDConfig, err := idputil.GetOpenIDConfiguration(
 		ctx, c.httpClient, openIDConfigURL, nil, logger, c.promMetrics)
 	if err != nil {

--- a/jwks/client_test.go
+++ b/jwks/client_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/acronis/go-authkit/idptest"
+	"github.com/acronis/go-authkit/internal/idputil"
 	"github.com/acronis/go-authkit/jwks"
 )
 
@@ -47,7 +48,7 @@ func TestClient_GetRSAPublicKey(t *testing.T) {
 		require.Error(t, err)
 		var openIDCfgErr *jwks.GetOpenIDConfigurationError
 		require.True(t, errors.As(err, &openIDCfgErr))
-		require.Equal(t, issuerConfigServer.URL+jwks.OpenIDConfigurationPath, openIDCfgErr.URL)
+		require.Equal(t, issuerConfigServer.URL+idputil.OpenIDConfigurationPath, openIDCfgErr.URL)
 		requireLocalhostConnRefusedError(t, openIDCfgErr.Inner)
 		require.Nil(t, pubKey)
 	})
@@ -63,7 +64,7 @@ func TestClient_GetRSAPublicKey(t *testing.T) {
 		require.Error(t, err)
 		var openIDCfgErr *jwks.GetOpenIDConfigurationError
 		require.True(t, errors.As(err, &openIDCfgErr))
-		require.Equal(t, issuerConfigServer.URL+jwks.OpenIDConfigurationPath, openIDCfgErr.URL)
+		require.Equal(t, issuerConfigServer.URL+idputil.OpenIDConfigurationPath, openIDCfgErr.URL)
 		require.EqualError(t, openIDCfgErr.Inner, "unexpected HTTP code 500")
 		require.Nil(t, pubKey)
 	})
@@ -80,7 +81,7 @@ func TestClient_GetRSAPublicKey(t *testing.T) {
 		require.Error(t, err)
 		var openIDCfgErr *jwks.GetOpenIDConfigurationError
 		require.True(t, errors.As(err, &openIDCfgErr))
-		require.Equal(t, issuerConfigServer.URL+jwks.OpenIDConfigurationPath, openIDCfgErr.URL)
+		require.Equal(t, issuerConfigServer.URL+idputil.OpenIDConfigurationPath, openIDCfgErr.URL)
 		var jsonSyntaxErr *json.SyntaxError
 		require.True(t, errors.As(openIDCfgErr, &jsonSyntaxErr))
 		require.Nil(t, pubKey)
@@ -98,7 +99,7 @@ func TestClient_GetRSAPublicKey(t *testing.T) {
 		var jwksErr *jwks.GetJWKSError
 		require.True(t, errors.As(err, &jwksErr))
 		require.Equal(t, jwksServer.URL, jwksErr.URL)
-		require.Equal(t, issuerConfigServer.URL+jwks.OpenIDConfigurationPath, jwksErr.OpenIDConfigurationURL)
+		require.Equal(t, issuerConfigServer.URL+idputil.OpenIDConfigurationPath, jwksErr.OpenIDConfigurationURL)
 		requireLocalhostConnRefusedError(t, jwksErr.Inner)
 		require.Nil(t, pubKey)
 	})
@@ -117,7 +118,7 @@ func TestClient_GetRSAPublicKey(t *testing.T) {
 		var jwksErr *jwks.GetJWKSError
 		require.True(t, errors.As(err, &jwksErr))
 		require.Equal(t, jwksServer.URL, jwksErr.URL)
-		require.Equal(t, issuerConfigServer.URL+jwks.OpenIDConfigurationPath, jwksErr.OpenIDConfigurationURL)
+		require.Equal(t, issuerConfigServer.URL+idputil.OpenIDConfigurationPath, jwksErr.OpenIDConfigurationURL)
 		require.EqualError(t, jwksErr.Inner, "unexpected HTTP code 500")
 		require.Nil(t, pubKey)
 	})
@@ -153,7 +154,7 @@ func TestClient_GetRSAPublicKey(t *testing.T) {
 		require.Error(t, err)
 		var openIDCfgErr *jwks.GetOpenIDConfigurationError
 		require.True(t, errors.As(err, &openIDCfgErr))
-		require.Equal(t, issuerConfigServer.URL+jwks.OpenIDConfigurationPath, openIDCfgErr.URL)
+		require.Equal(t, issuerConfigServer.URL+idputil.OpenIDConfigurationPath, openIDCfgErr.URL)
 		require.ErrorIs(t, openIDCfgErr, context.Canceled)
 		require.Nil(t, pubKey)
 	})


### PR DESCRIPTION
This update introduces a caching mechanism for the OpenID Provider Configuration metadata. By caching the response from the .well-known/openid-configuration endpoint, we eliminate the need to perform a GET request for each token introspection when a static endpoint is not configured. This reduces unnecessary network calls, improves performance, and ensures efficient handling of token introspection requests.
