### PR TITLE
Fix tests for go >= 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go: [ '1.20' ]
+        go: [ '1.20', '1.21', '1.22', '1.23', '1.24' ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
       fail-fast: true
     runs-on: ${{ matrix.os }}

--- a/internal/jwk/key_test.go
+++ b/internal/jwk/key_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"math/big"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -172,6 +173,10 @@ func TestDecodePrivateKeyFails(t *testing.T) {
 
 	privKey, err = key.DecodePrivateKey()
 	require.Error(t, err, "exported D is not a valid base64url")
-	require.ErrorContains(t, err, "public exponent too small")
+	if goVersion := runtime.Version(); goVersion >= "go1.24" {
+		require.ErrorContains(t, err, "input overflows the modulus")
+	} else {
+		require.ErrorContains(t, err, "public exponent too small")
+	}
 	require.Nil(t, privKey)
 }


### PR DESCRIPTION
rsa package updated the error message in go 1.24. This fix addresses tests with old and new strings. Besides, it also adds multiple tests with different go versions.