### PR TITLE
feat: handle introspection service unavailability with throttling support

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -49,7 +49,7 @@ func NewJWTParser(cfg *Config, opts ...JWTParserOption) (JWTParser, error) {
 	if jwksCacheUpdateMinInterval == 0 {
 		jwksCacheUpdateMinInterval = jwks.DefaultCacheUpdateMinInterval
 	}
-	httpClient := idputil.MakeDefaultHTTPClient(
+	httpClient := idputil.MakeHTTPClientWithFastRetryPolicy(
 		time.Duration(cfg.HTTPClient.RequestTimeout), options.loggerProvider,
 		options.requestIDProvider, options.userAgent,
 	)
@@ -220,7 +220,7 @@ func NewTokenIntrospector(
 		}
 	}
 
-	httpClient := idputil.MakeDefaultHTTPClient(
+	httpClient := idputil.MakeHTTPClientWithFastRetryPolicy(
 		time.Duration(cfg.HTTPClient.RequestTimeout), options.loggerProvider, options.requestIDProvider, options.userAgent)
 
 	introspectorOpts := idptoken.IntrospectorOpts{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -48,12 +48,14 @@ const (
 	HTTPRequestErrorDecodeBody           = "decode_body_error"
 	HTTPRequestErrorUnexpectedStatusCode = "unexpected_status_code"
 
-	TokenIntrospectionStatusActive            = "active"
-	TokenIntrospectionStatusNotActive         = "not_active"
-	TokenIntrospectionStatusNotNeeded         = "not_needed"
-	TokenIntrospectionStatusNotIntrospectable = "not_introspectable"
-	TokenIntrospectionStatusInvalidClaims     = "invalid_claims"
-	TokenIntrospectionStatusError             = "error"
+	TokenIntrospectionStatusActive             = "active"
+	TokenIntrospectionStatusNotActive          = "not_active"
+	TokenIntrospectionStatusNotNeeded          = "not_needed"
+	TokenIntrospectionStatusNotIntrospectable  = "not_introspectable"
+	TokenIntrospectionStatusInvalidClaims      = "invalid_claims"
+	TokenIntrospectionStatusServiceUnavailable = "service_unavailable"
+	TokenIntrospectionStatusThrottled          = "throttled"
+	TokenIntrospectionStatusError              = "error"
 )
 
 type Source string

--- a/jwks/client.go
+++ b/jwks/client.go
@@ -60,7 +60,8 @@ func NewClient() *Client {
 func NewClientWithOpts(opts ClientOpts) *Client {
 	promMetrics := metrics.GetPrometheusMetrics(opts.PrometheusLibInstanceLabel, metrics.SourceJWKSClient)
 	if opts.HTTPClient == nil {
-		opts.HTTPClient = idputil.MakeDefaultHTTPClient(idputil.DefaultHTTPRequestTimeout, opts.LoggerProvider, nil, libinfo.UserAgent())
+		opts.HTTPClient = idputil.MakeHTTPClientWithFastRetryPolicy(
+			idputil.DefaultHTTPRequestTimeout, opts.LoggerProvider, nil, libinfo.UserAgent())
 	}
 	return &Client{httpClient: opts.HTTPClient, loggerProvider: opts.LoggerProvider, promMetrics: promMetrics}
 }


### PR DESCRIPTION
- Handle HTTP 429/503 and gRPC ResourceExhausted/Unavailable token introspection errors with retry-after metadata propagation
- Update middleware to respond with proper HTTP 503 status and retry-after headers
- Switch to fast retry policy HTTP client to reduce introspection latency during temporary failures
- Add comprehensive test coverage for service unavailability and throttling scenarios