### PR TITLE
feat: add singleflight pattern to prevent duplicate token introspections

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -502,12 +502,12 @@ func TestTokenIntrospectorSetUserAgent(t *gotesting.T) {
 			_, err = introspector.IntrospectToken(context.Background(), opaqueToken)
 			require.NoError(t, err)
 			if tt.expectedUserAgent != "" {
-				require.Equal(t, fmt.Sprintf("%s %s", tt.expectedUserAgent, libinfo.UserAgent()), httpServerIntrospector.LastUserAgentHeader)
+				require.Equal(t, fmt.Sprintf("%s %s", tt.expectedUserAgent, libinfo.UserAgent()), httpServerIntrospector.LastUserAgentHeader())
 				if tt.cfg.Introspection.GRPC.Endpoint != "" {
-					require.Contains(t, grpcServerIntrospector.LastUserAgentMeta, tt.expectedUserAgent)
+					require.Contains(t, grpcServerIntrospector.LastUserAgentMeta(), tt.expectedUserAgent)
 				}
 			} else {
-				require.Contains(t, httpServerIntrospector.LastUserAgentHeader, defaultUserAgent)
+				require.Contains(t, httpServerIntrospector.LastUserAgentHeader(), defaultUserAgent)
 			}
 		})
 	}

--- a/idptoken/grpc_client_test.go
+++ b/idptoken/grpc_client_test.go
@@ -223,12 +223,12 @@ func TestGRPCClient_IntrospectToken(t *gotesting.T) {
 				} else {
 					require.Equal(t, req.expectedResult, result)
 				}
-				require.Equal(t, req.serverLastAuthorizationMetaExpected, grpcServerTokenIntrospector.LastAuthorizationMeta,
+				require.Equal(t, req.serverLastAuthorizationMetaExpected, grpcServerTokenIntrospector.LastAuthorizationMeta(),
 					fmt.Sprintf("unexpected server auth meta with introspection request number %d", req.requestNumber))
-				require.Equal(t, req.serverLastSessionMetaExpected, grpcServerTokenIntrospector.LastSessionMeta,
+				require.Equal(t, req.serverLastSessionMetaExpected, grpcServerTokenIntrospector.LastSessionMeta(),
 					fmt.Sprintf("unexpected server session meta with introspection request number %d", req.requestNumber))
 				if req.expectedResult != nil {
-					require.Equal(t, req.tokenToIntrospect, grpcServerTokenIntrospector.LastRequest.Token,
+					require.Equal(t, req.tokenToIntrospect, grpcServerTokenIntrospector.LastRequest().Token,
 						fmt.Sprintf("unexpected introspection result with introspection request number %d", req.requestNumber))
 				}
 			}
@@ -382,10 +382,10 @@ func TestGRPCClient_ExchangeToken(t *gotesting.T) {
 				require.Equal(t, tt.expectedTokenData, tokenData)
 			}
 			if tt.expectedRequest != nil {
-				require.Equal(t, tt.expectedRequest.GrantType, grpcServerTokenCreator.LastRequest.GrantType)
-				require.Equal(t, tt.expectedRequest.Assertion, grpcServerTokenCreator.LastRequest.Assertion)
+				require.Equal(t, tt.expectedRequest.GrantType, grpcServerTokenCreator.LastRequest().GrantType)
+				require.Equal(t, tt.expectedRequest.Assertion, grpcServerTokenCreator.LastRequest().Assertion)
 				require.Equal(t, tt.expectedRequest.NotRequiredIntrospection,
-					grpcServerTokenCreator.LastRequest.NotRequiredIntrospection)
+					grpcServerTokenCreator.LastRequest().NotRequiredIntrospection)
 			}
 		})
 	}

--- a/idptoken/introspector_test.go
+++ b/idptoken/introspector_test.go
@@ -640,21 +640,21 @@ func TestIntrospector_IntrospectToken(t *gotesting.T) {
 				require.Equal(t, tt.expectedResult, result)
 			}
 
-			require.Equal(t, tt.expectedHTTPSrvCalled, httpServerIntrospector.Called)
+			require.Equal(t, tt.expectedHTTPSrvCalled, httpServerIntrospector.Called())
 			if tt.expectedHTTPSrvCalled {
-				require.Equal(t, tt.tokenToIntrospect, httpServerIntrospector.LastIntrospectedToken)
-				require.Equal(t, "Bearer "+tt.accessToken, httpServerIntrospector.LastAuthorizationHeader)
+				require.Equal(t, tt.tokenToIntrospect, httpServerIntrospector.LastIntrospectedToken())
+				require.Equal(t, "Bearer "+tt.accessToken, httpServerIntrospector.LastAuthorizationHeader())
 				if tt.expectedHTTPFormVals == nil {
 					tt.expectedHTTPFormVals = url.Values{"token": {tt.tokenToIntrospect}}
 				}
-				require.Equal(t, tt.expectedHTTPFormVals, httpServerIntrospector.LastFormValues)
+				require.Equal(t, tt.expectedHTTPFormVals, httpServerIntrospector.LastFormValues())
 			}
 
-			require.Equal(t, tt.expectedGRPCSrvCalled, grpcServerIntrospector.Called)
+			require.Equal(t, tt.expectedGRPCSrvCalled, grpcServerIntrospector.Called())
 			if tt.expectedGRPCSrvCalled {
-				require.Equal(t, tt.tokenToIntrospect, grpcServerIntrospector.LastRequest.Token)
-				require.Equal(t, tt.expectedGRPCScopeFilter, grpcServerIntrospector.LastRequest.GetScopeFilter())
-				require.Equal(t, "Bearer "+tt.accessToken, grpcServerIntrospector.LastAuthorizationMeta)
+				require.Equal(t, tt.tokenToIntrospect, grpcServerIntrospector.LastRequest().Token)
+				require.Equal(t, tt.expectedGRPCScopeFilter, grpcServerIntrospector.LastRequest().GetScopeFilter())
+				require.Equal(t, "Bearer "+tt.accessToken, grpcServerIntrospector.LastAuthorizationMeta())
 			}
 		})
 	}
@@ -926,9 +926,9 @@ func TestCachingIntrospector_IntrospectTokenWithCache(t *gotesting.T) {
 					idpSrv.ServedCounts()[idptest.OpenIDConfigurationPath])
 
 				if tt.expectedSrvCounts[i][idptest.TokenIntrospectionEndpointPath] > 0 {
-					require.Equal(t, token, serverIntrospector.LastIntrospectedToken)
-					require.Equal(t, "Bearer "+accessToken, serverIntrospector.LastAuthorizationHeader)
-					require.Equal(t, url.Values{"token": {token}}, serverIntrospector.LastFormValues)
+					require.Equal(t, token, serverIntrospector.LastIntrospectedToken())
+					require.Equal(t, "Bearer "+accessToken, serverIntrospector.LastAuthorizationHeader())
+					require.Equal(t, url.Values{"token": {token}}, serverIntrospector.LastFormValues())
 				}
 
 				time.Sleep(tt.delay)


### PR DESCRIPTION
- Ensure only one introspection per unique token happens simultaneously
- Add comprehensive test coverage for singleflight behavior with different scenarios