### PR TITLE
Improve idptoken provider: fix race conditions and add retry-aware errors

### DIFF
--- a/idptoken/provider_internal_test.go
+++ b/idptoken/provider_internal_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright © 2025 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package idptoken
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUniqAndSort(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "single element",
+			input:    []string{"a"},
+			expected: []string{"a"},
+		},
+		{
+			name:     "no duplicates",
+			input:    []string{"c", "a", "b"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "with duplicates",
+			input:    []string{"b", "a", "b", "c", "a"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "all same",
+			input:    []string{"a", "a", "a"},
+			expected: []string{"a"},
+		},
+		{
+			name:     "already sorted unique",
+			input:    []string{"a", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "already sorted with duplicates",
+			input:    []string{"a", "a", "b", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "reverse order",
+			input:    []string{"c", "b", "a"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "multiple duplicates",
+			input:    []string{"d", "b", "a", "c", "b", "d", "a"},
+			expected: []string{"a", "b", "c", "d"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy since the function modifies in-place
+			inputCopy := make([]string, len(tt.input))
+			copy(inputCopy, tt.input)
+
+			result := uniqAndSort(inputCopy)
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("uniqAndSort(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/idputil/errors.go
+++ b/internal/idputil/errors.go
@@ -1,0 +1,23 @@
+/*
+Copyright © 2025 Acronis International GmbH.
+
+Released under MIT license.
+*/
+
+package idputil
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// UnexpectedResponseError represents an error that occurs when an unexpected HTTP response is received.
+// It captures the HTTP status code and response headers for further analysis.
+type UnexpectedResponseError struct {
+	StatusCode int
+	Header     http.Header
+}
+
+func (e *UnexpectedResponseError) Error() string {
+	return fmt.Sprintf("unexpected HTTP status code %d", e.StatusCode)
+}

--- a/internal/idputil/openid_configuration.go
+++ b/internal/idputil/openid_configuration.go
@@ -58,7 +58,10 @@ func GetOpenIDConfiguration(
 	if resp.StatusCode != http.StatusOK {
 		promMetrics.ObserveHTTPClientRequest(
 			http.MethodGet, targetURL, resp.StatusCode, elapsed, metrics.HTTPRequestErrorUnexpectedStatusCode)
-		return OpenIDConfiguration{}, fmt.Errorf("unexpected HTTP code %d", resp.StatusCode)
+		return OpenIDConfiguration{}, &UnexpectedResponseError{
+			StatusCode: resp.StatusCode,
+			Header:     resp.Header.Clone(),
+		}
 	}
 
 	var openIDCfg OpenIDConfiguration

--- a/jwks/client_test.go
+++ b/jwks/client_test.go
@@ -65,7 +65,7 @@ func TestClient_GetRSAPublicKey(t *testing.T) {
 		var openIDCfgErr *jwks.GetOpenIDConfigurationError
 		require.True(t, errors.As(err, &openIDCfgErr))
 		require.Equal(t, issuerConfigServer.URL+idputil.OpenIDConfigurationPath, openIDCfgErr.URL)
-		require.EqualError(t, openIDCfgErr.Inner, "unexpected HTTP code 500")
+		require.EqualError(t, openIDCfgErr.Inner, "unexpected HTTP status code 500")
 		require.Nil(t, pubKey)
 	})
 


### PR DESCRIPTION
## fix: resolve data races in idptoken provider
- Add proper synchronization for tokenIssuers map access using RWMutex
- Replace nextRefresh RWMutex with atomic.Value for lockless reads
- Use atomic.Value for oauth2Issuer clientSecret and tokenURL fields
- Add mutex to oauth2Issuer for safe tokenURL initialization
- Refactor token caching to reduce lock contention and eliminate race conditions
- Store custom headers in tokenData to preserve them during refresh
- Add GetAll method to InMemoryTokenCache for safe iteration
- Improve token refresh loop to work with snapshot of tokens

## feat: propagate 503/429 errors with retry information from OpenID configuration and token endpoints
- Return ServiceUnavailableError for 503 responses from both OpenID config and token endpoints
- Return ThrottledError for 429 responses from both endpoints
- Extract and include Retry-After header values in error responses to enable proper retry backoff
- Add comprehensive test coverage for error scenarios in both provider and introspector components